### PR TITLE
Filtering regex support

### DIFF
--- a/PackageVisualizer.sln
+++ b/PackageVisualizer.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageVisualizer", "PackageVisualizer\PackageVisualizer.csproj", "{B4446189-4955-4971-999C-1BEF46846F85}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{94D10594-D830-4C8B-BF55-ECE7A08214C7}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +23,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B504DDF9-C690-4F0B-A0C1-C6A2AE2F0692}
 	EndGlobalSection
 EndGlobal

--- a/PackageVisualizer/Design/FilterDialog.xaml
+++ b/PackageVisualizer/Design/FilterDialog.xaml
@@ -1,0 +1,34 @@
+﻿<platformUi:DialogWindow x:Class="PackageVisualizer.Design.FilterDialog"
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+            xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+            xmlns:local="clr-namespace:PackageVisualizer.Design"
+            xmlns:platformUi="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.14.0"
+            mc:Ignorable="d"
+            Height="122.286" 
+            Width="389.714"
+            ResizeMode="NoResize" 
+            Title="Package Filter" 
+            DataContext="{x:Static local:ViewModelLocator.FilterViewModel}">
+    <Grid FocusManager.FocusedElement="{Binding ElementName=txtFilter}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Label Content="Filter" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+        <TextBox Name="txtFilter" Text="{Binding PackageFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" Grid.Column="1" VerticalContentAlignment="Center" HorizontalContentAlignment="Center">
+            <TextBox.ToolTip>Type the package name here which you would like to filter on. This is regex compatible.</TextBox.ToolTip>
+            <TextBox.InputBindings>
+                <KeyBinding Key="Enter" Command="{Binding ApplyCommand}" CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type platformUi:DialogWindow}}}"/>
+            </TextBox.InputBindings>
+        </TextBox>
+
+        <Button Grid.Row="1" Grid.Column="1" Content="Apply Filter" IsEnabled="True" Command="{Binding ApplyCommand}" CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type platformUi:DialogWindow}}}"/>
+    </Grid>
+</platformUi:DialogWindow>
+

--- a/PackageVisualizer/Design/FilterDialog.xaml.cs
+++ b/PackageVisualizer/Design/FilterDialog.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.VisualStudio.PlatformUI;
+
+namespace PackageVisualizer.Design
+{
+    /// <summary>
+    /// Interaction logic for FilterDialog.xaml
+    /// </summary>
+    public partial class FilterDialog : DialogWindow
+    {
+        public FilterDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/PackageVisualizer/Design/FilterViewModel.cs
+++ b/PackageVisualizer/Design/FilterViewModel.cs
@@ -1,0 +1,29 @@
+﻿
+using System.Windows;
+using System.Windows.Input;
+using Microsoft.VisualStudio.PlatformUI;
+
+namespace PackageVisualizer.Design
+{
+    public class FilterViewModel : ObservableObject
+    {
+        private string _packageFilter;
+
+        public string PackageFilter
+        {
+            get => _packageFilter;
+            set
+            {
+                _packageFilter = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public ICommand ApplyCommand { get; set; }
+
+        public FilterViewModel()
+        {
+            ApplyCommand = new DelegateCommand(s => ((DialogWindow)s).Close());
+        }
+    }
+}

--- a/PackageVisualizer/Design/ObservableObject.cs
+++ b/PackageVisualizer/Design/ObservableObject.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace PackageVisualizer.Design
+{
+    public class ObservableObject : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+        
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/PackageVisualizer/Design/ViewModelLocator.cs
+++ b/PackageVisualizer/Design/ViewModelLocator.cs
@@ -1,0 +1,8 @@
+﻿
+namespace PackageVisualizer.Design
+{
+    public static class ViewModelLocator
+    {
+        public static FilterViewModel FilterViewModel => new FilterViewModel();
+    }
+}

--- a/PackageVisualizer/PackageVisualizer.csproj
+++ b/PackageVisualizer/PackageVisualizer.csproj
@@ -73,11 +73,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Design\FilterDialog.xaml.cs">
+      <DependentUpon>FilterDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Design\FilterViewModel.cs" />
+    <Compile Include="Design\ObservableObject.cs" />
     <Compile Include="SolutionHelper.cs" />
     <Compile Include="ObjectDumper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DomainObjects.cs" />
     <Compile Include="NugetPackageVisualizer.cs" />
+    <Compile Include="Design\ViewModelLocator.cs" />
     <Compile Include="VisualizerCommand.cs" />
     <Compile Include="VisualizerCommandPackage.cs" />
     <Compile Include="XElementExtensions.cs" />
@@ -97,6 +103,7 @@
     <Content Include="Resources\VisualizerCommandPackage.ico" />
     <VSCTCompile Include="VisualizerCommandPackage.vsct">
       <ResourceName>Menus.ctmenu</ResourceName>
+      <SubType>Designer</SubType>
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
@@ -203,6 +210,8 @@
       <HintPath>..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
@@ -211,8 +220,10 @@
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="VSPackage.resx">
@@ -231,6 +242,12 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="Design\FilterDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/PackageVisualizer/VisualizerCommand.cs
+++ b/PackageVisualizer/VisualizerCommand.cs
@@ -99,9 +99,10 @@ namespace PackageVisualizer
                             packageFilter = suppliedFilter;
                     }
 
-                    var visualizer = new NugetPackageVisualizer(vsEnvironment, packageFilter);
+                    var visualizer = new NugetPackageVisualizer(vsEnvironment);
                     var dgmlFilePath = Path.GetDirectoryName(solutionFullName) + @"\NugetVisualizerOutput.dgml";
-                    visualizer.GenerateDgmlFile(dgmlFilePath);
+
+                    visualizer.GenerateDgmlFile(dgmlFilePath, packageFilter);
                     vsEnvironment.ItemOperations.OpenFile(dgmlFilePath);
                 }
                 else
@@ -127,7 +128,7 @@ namespace PackageVisualizer
             }
         }
         
-        private bool SolutionIsLoaded(Solution solution)
+        private static bool SolutionIsLoaded(Solution solution)
         {
             try
             {

--- a/PackageVisualizer/VisualizerCommandPackage.cs
+++ b/PackageVisualizer/VisualizerCommandPackage.cs
@@ -7,6 +7,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace PackageVisualizer
 {
@@ -27,6 +28,7 @@ namespace PackageVisualizer
     /// To get loaded into VS, the package must be referred by &lt;Asset Type="Microsoft.VisualStudio.VsPackage" ...&gt; in .vsixmanifest file.
     /// </para>
     /// </remarks>
+    [ProvideAutoLoad(UIContextGuids.NoSolution)]
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]

--- a/PackageVisualizer/VisualizerCommandPackage.vsct
+++ b/PackageVisualizer/VisualizerCommandPackage.vsct
@@ -23,51 +23,40 @@
   <!--The Commands section is where commands, menus, and menu groups are defined.
       This section uses a Guid to identify the package that provides the command defined inside it. -->
   <Commands package="guidVisualizerCommandPackage">
-    <!-- Inside this section we have different sub-sections: one for the menus, another
-    for the menu groups, one for the buttons (the actual commands), one for the combos
-    and the last one for the bitmaps used. Each element is identified by a command id that
-    is a unique pair of guid and numeric identifier; the guid part of the identifier is usually
-    called "command set" and is used to group different command inside a logically related
-    group; your package should define its own command set in order to avoid collisions
-    with command ids defined by other packages. -->
-
-    <!-- In this section you can define new menu groups. A menu group is a container for
-         other menus or buttons (commands); from a visual point of view you can see the
-         group as the part of a menu contained between two lines. The parent of a group
-         must be a menu. -->
     <Groups>
       <Group guid="guidVisualizerCommandPackageCmdSet" id="MyMenuGroup" priority="0x0600">
-        <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_TOOLS"/>
+        <Parent guid="guidVisualizerCommandPackageCmdSet" id="TopLevelMenu"/>
       </Group>
     </Groups>
-
-    <!--Buttons section. -->
-    <!--This section defines the elements the user can interact with, like a menu command or a button
-        or combo box in a toolbar. -->
-    <Buttons>
-      <!--To define a menu group you have to specify its ID, the parent menu and its display priority.
-          The command is visible and enabled by default. If you need to change the visibility, status, etc, you can use
-          the CommandFlag node.
-          You can add more than one CommandFlag node e.g.:
-              <CommandFlag>DefaultInvisible</CommandFlag>
-              <CommandFlag>DynamicVisibility</CommandFlag>
-          If you do not want an image next to your command, remove the Icon node /> -->
-      <Button guid="guidVisualizerCommandPackageCmdSet" id="VisualizerCommandId" priority="0x0100" type="Button">
-        <Parent guid="guidVisualizerCommandPackageCmdSet" id="MyMenuGroup" />
-        <Icon guid="guidImages" id="bmpPic1" />
+    <Menus>
+      <Menu guid="guidVisualizerCommandPackageCmdSet" id="TopLevelMenu" priority="0x700" type="Menu">
+        <Parent guid="guidSHLMainMenu" id="IDG_VS_MM_TOOLSADDINS" />
         <Strings>
           <ButtonText>Nuget Package Visualizer</ButtonText>
+          <CommandName>Nuget Package Visualizer</CommandName>
+        </Strings>
+      </Menu>
+    </Menus>
+
+    <Buttons>
+      <Button guid="guidVisualizerCommandPackageCmdSet" id="VisualizerCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidVisualizerCommandPackageCmdSet" id="MyMenuGroup"/>
+        <Icon guid="guidImages" id="bmpPic1" />
+        <Strings>
+          <ButtonText>Generate</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidVisualizerCommandPackageCmdSet" id="FilterVisualizerCommandId" priority="0x0110" type="Button">
+        <Parent guid="guidVisualizerCommandPackageCmdSet" id="MyMenuGroup"/>
+        <Icon guid="guidImages" id="bmpPic1" />
+        <Strings>
+          <ButtonText>Generate (with Filter)</ButtonText>
+          <ToolTipText>Generates a NuGet reference map for specific packages.</ToolTipText>
         </Strings>
       </Button>
     </Buttons>
-
-    <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
+    
     <Bitmaps>
-      <!--  The bitmap id is defined in a way that is a little bit different from the others:
-            the declaration starts with a guid for the bitmap strip, then there is the resource id of the
-            bitmap strip containing the bitmaps and then there are the numeric ids of the elements used
-            inside a button definition. An important aspect of this declaration is that the element id
-            must be the actual index (1-based) of the bitmap inside the bitmap strip. -->
       <Bitmap guid="guidImages" href="Resources\VisualizerCommand.png" usedList="bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows, bmpPicStrikethrough"/>
     </Bitmaps>
   </Commands>
@@ -78,8 +67,10 @@
 
     <!-- This is the guid used to group the menu commands together -->
     <GuidSymbol name="guidVisualizerCommandPackageCmdSet" value="{cb4a6e94-bba7-4a6f-9a37-6fe4e4aa8434}">
-      <IDSymbol name="MyMenuGroup" value="0x1020" />
+      <IDSymbol name="TopLevelMenu" value="0x1020" />
       <IDSymbol name="VisualizerCommandId" value="0x0100" />
+      <IDSymbol name="FilterVisualizerCommandId" value="0x1100" />
+      <IDSymbol name="MyMenuGroup" value="0x0800"/>
     </GuidSymbol>
 
     <GuidSymbol name="guidImages" value="{c70993ef-d29d-48db-8237-0e96dd591a98}" >

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # VisualStudio2017PackageVisualizer
-Implementation of the Visual Studio 2013 package visualizer as a Visual Studio 2017 extension. (Currently no support for .NET core projects)
+Implementation of the Visual Studio 2013 package visualizer as a Visual Studio 2017 extension.
 
-How to Use: After building the solution, there will be a PackageVisualizer.vsix file in the bin. Use that to install the extension for VS2017. Once it is complete, you'll have to restart visual studio. After that is done, the extension should show up directly under Tools as "Nuget Package Visualizer". Once you run the extension/command, you will get an output file with your results called NugetVisualizerOutput.dgml.
+# Usage
+After building the solution, there will be a PackageVisualizer.vsix file in the bin. Use that to install the extension for VS2017. Once it is complete, you'll have to restart visual studio. After that is done, the extension should show up in the Visual Studio Menu as "Nuget Package Visualizer". Once you run the extension/command, you will get an output file with your results called NugetVisualizerOutput.dgml.
+You can also create a dgml file for specific packages by choosing the `Generate (with Filter)` option, this supports regex and will create a dgml file containing only the packages which match your filter.


### PR DESCRIPTION
Add functionality for filtering on package names when creating the diagram.

* Added view with view model (graphic design was never my strong point).
* Converted "Nuget Package Visualizer" to a menu with two buttons.
* Moved "Nuget Package Visualizer" menu from "Tools" to its own menu.
* Refactored the `LoadPackageConfig` method to instead take package config file parameters for reusability.
* Refactored the `LoadPackageConfig` method to instead execute in one single `foreach` loop.
* Added `ProvideAutoLoadAttribute` to allow for debugging in an experimental Visual Studio instance.

Please review, test and provide feedback where necessary.

Resolves #6 